### PR TITLE
Add channels to Solidity compiler(s)

### DIFF
--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -19,6 +19,7 @@ Break: 'break';
 Bytes: 'bytes';
 Calldata: 'calldata';
 Catch: 'catch';
+ChanCreate: 'chancreate';
 Constant: 'constant';
 Constructor: 'constructor';
 Continue: 'continue';
@@ -118,6 +119,7 @@ Period: '.';
 Conditional: '?';
 DoubleArrow: '=>';
 RightArrow: '->';
+LeftArrow: '<-';
 
 Assign: '=';
 AssignBitOr: '|=';
@@ -294,7 +296,7 @@ YulEVMBuiltin:
 	| 'delegatecall' | 'staticcall' | 'return' | 'revert' | 'selfdestruct' | 'invalid'
 	| 'log0' | 'log1' | 'log2' | 'log3' | 'log4' | 'chainid' | 'origin' | 'gasprice'
 	| 'blockhash' | 'coinbase' | 'timestamp' | 'number' | 'difficulty' | 'prevrandao'
-	| 'gaslimit' | 'basefee' | 'yield' | 'spawn';
+	| 'gaslimit' | 'basefee' | 'yield' | 'spawn' | 'chancreate', 'chansend', 'chanrecv';
 
 YulLBrace: '{' -> pushMode(YulMode);
 YulRBrace: '}' -> popMode;

--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -379,7 +379,7 @@ expression:
 ;
 
 //@doc:inline
-assignOp: Assign | AssignBitOr | AssignBitXor | AssignBitAnd | AssignShl | AssignSar | AssignShr | AssignAdd | AssignSub | AssignMul | AssignDiv | AssignMod;
+assignOp: Assign | AssignBitOr | AssignBitXor | AssignBitAnd | AssignShl | AssignSar | AssignShr | AssignAdd | AssignSub | AssignMul | AssignDiv | AssignMod | LeftArrow;
 tupleExpression: LParen (expression? ( Comma expression?)* ) RParen;
 /**
  * An inline array expression denotes a statically sized array of the common type of the contained expressions.
@@ -430,6 +430,7 @@ statement:
 	| tryStatement
 	| returnStatement
 	| emitStatement
+  | spawnStatement
 	| revertStatement
 	| assemblyStatement
 ;

--- a/libevmasm/Instruction.cpp
+++ b/libevmasm/Instruction.cpp
@@ -322,7 +322,7 @@ static std::map<Instruction, InstructionInfo> const c_instructionInfo =
 	{ Instruction::RETURN,		{ "RETURN",			0, 2, 0, true, Tier::Zero } },
 	{ Instruction::DELEGATECALL,	{ "DELEGATECALL",	0, 6, 1, true, Tier::Special } },
 	{ Instruction::STATICCALL,	{ "STATICCALL",		0, 6, 1, true, Tier::Special } },
-	{ Instruction::CHANCREATE,  { "CHANCREATE",     0, 0, 1, true, Tier::VeryLow } }, // TODO: Gas, and side effect
+	{ Instruction::CHANCREATE,  { "CHANCREATE",     0, 1, 1, true, Tier::VeryLow } }, // TODO: Gas, and side effect
 	{ Instruction::CHANSEND,    { "CHANSEND",       0, 2, 0, true, Tier::VeryLow } }, // TODO
     { Instruction::CHANRECV,    { "CHANRECV",       0, 1, 1, true, Tier::VeryLow } }, // TODO
 	{ Instruction::SPAWN,       { "SPAWN",          0, 1, 0, true, Tier::VeryLow } }, // TODO: Gase, Side effect

--- a/libevmasm/Instruction.cpp
+++ b/libevmasm/Instruction.cpp
@@ -167,6 +167,9 @@ std::map<std::string, Instruction> const solidity::evmasm::c_instructions =
 	{ "CALL", Instruction::CALL },
 	{ "CALLCODE", Instruction::CALLCODE },
 	{ "STATICCALL", Instruction::STATICCALL },
+	{ "CHANCREATE", Instruction::CHANCREATE },
+	{ "CHANSEND", Instruction::CHANSEND },
+	{ "CHANRECV", Instruction::CHANRECV },
 	{ "SPAWN", Instruction::SPAWN },
 	{ "YIELD", Instruction::YIELD },
 	{ "RETURN", Instruction::RETURN },
@@ -319,6 +322,9 @@ static std::map<Instruction, InstructionInfo> const c_instructionInfo =
 	{ Instruction::RETURN,		{ "RETURN",			0, 2, 0, true, Tier::Zero } },
 	{ Instruction::DELEGATECALL,	{ "DELEGATECALL",	0, 6, 1, true, Tier::Special } },
 	{ Instruction::STATICCALL,	{ "STATICCALL",		0, 6, 1, true, Tier::Special } },
+	{ Instruction::CHANCREATE,  { "CHANCREATE",     0, 0, 1, true, Tier::VeryLow } }, // TODO: Gas, and side effect
+	{ Instruction::CHANSEND,    { "CHANSEND",       0, 2, 0, true, Tier::VeryLow } }, // TODO
+    { Instruction::CHANRECV,    { "CHANRECV",       0, 1, 1, true, Tier::VeryLow } }, // TODO
 	{ Instruction::SPAWN,       { "SPAWN",          0, 1, 0, true, Tier::VeryLow } }, // TODO: Gase, Side effect
 	{ Instruction::YIELD,       { "YIELD",          0, 0, 0, true, Tier::VeryLow } }, // TODO: Gas & SideEffects
 	{ Instruction::CREATE2,		{ "CREATE2",		0, 4, 1, true, Tier::Special } },

--- a/libevmasm/Instruction.h
+++ b/libevmasm/Instruction.h
@@ -182,6 +182,9 @@ enum class Instruction: uint8_t
 	RETURN,				///< halt execution returning output data
 	DELEGATECALL,		///< like CALLCODE but keeps caller's value and sender
 	CREATE2 = 0xf5,		///< create new account with associated code at address `sha3(0xff + sender + salt + init code) % 2**160`
+	CHANCREATE = 0xf6,	///< create new coroutine channel in scope context
+	CHANSEND   = 0xf7,	///< send message to coroutine channel
+	CHANRECV   = 0xf8,	///< receive message from coroutine channel
 	STATICCALL = 0xfa,	///< like CALL but disallow state modifications
 
 	SPAWN = 0xfb,		///< add coroutine to queue based on attached function call

--- a/libevmasm/SemanticInformation.cpp
+++ b/libevmasm/SemanticInformation.cpp
@@ -249,6 +249,8 @@ bool SemanticInformation::altersControlFlow(AssemblyItem const& _item)
 	case Instruction::SELFDESTRUCT:
 	case Instruction::STOP:
 	case Instruction::YIELD:
+	case Instruction::CHANSEND:
+	case Instruction::CHANRECV:
 	case Instruction::INVALID:
 	case Instruction::REVERT:
 		return true;

--- a/libevmasm/SimplificationRule.h
+++ b/libevmasm/SimplificationRule.h
@@ -147,6 +147,9 @@ struct EVMBuiltins
 	static auto constexpr STATICCALL = PatternGenerator<Instruction::STATICCALL>{};
 	static auto constexpr RETURN = PatternGenerator<Instruction::RETURN>{};
 	static auto constexpr DELEGATECALL = PatternGenerator<Instruction::DELEGATECALL>{};
+	static auto constexpr CHANCREATE = PatternGenerator<Instruction::CHANCREATE>{};
+	static auto constexpr CHANSEND = PatternGenerator<Instruction::CHANSEND>{};
+	static auto constexpr CHANRECV = PatternGenerator<Instruction::CHANRECV>{};
 	static auto constexpr SPAWN = PatternGenerator<Instruction::SPAWN>{};
 	static auto constexpr YIELD = PatternGenerator<Instruction::YIELD>{};
 	static auto constexpr CREATE2 = PatternGenerator<Instruction::CREATE2>{};

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -559,6 +559,8 @@ void Scanner::scanToken()
 				token = selectToken(Token::LessThanOrEqual);
 			else if (m_char == '<')
 				token = selectToken('=', Token::AssignShl, Token::SHL);
+			else if (m_char == '-')
+				token = selectToken(Token::LeftArrow);
 			else
 				token = Token::LessThan;
 			break;

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -147,7 +147,6 @@ namespace solidity::langutil
 	K(Assembly, "assembly", 0)                                         \
 	K(Break, "break", 0)                                               \
 	K(Catch, "catch", 0)                                               \
-	K(ChanCreate, "chancreate", 0)                                     \
 	K(Constant, "constant", 0)                                         \
 	K(Constructor, "constructor", 0)                                   \
 	K(Continue, "continue", 0)                                         \
@@ -196,7 +195,6 @@ namespace solidity::langutil
 	K(View, "view", 0)                                                 \
 	K(Virtual, "virtual", 0)                                           \
 	K(While, "while", 0)                                               \
-	K(Yield, "yield", 0)                                               \
 	\
 	/* Ether subdenominations */                                       \
 	K(SubWei, "wei", 0)                                                \
@@ -215,6 +213,7 @@ namespace solidity::langutil
 	K(String, "string", 0)                                             \
 	K(Address, "address", 0)                                           \
 	K(Bool, "bool", 0)                                                 \
+	K(Channel, "channel", 0)                                           \
 	K(Fixed, "fixed", 0)                                               \
 	K(UFixed, "ufixed", 0)                                             \
 	T(IntM, "intM", 0)                                                 \

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -81,6 +81,7 @@ namespace solidity::langutil
 	T(Conditional, "?", 3)                                              \
 	T(DoubleArrow, "=>", 0)                                             \
 	T(RightArrow, "->", 0)                                              \
+	T(LeftArrow, "<-", 0)                                               \
 	\
 	/* Assignment operators. */										\
 	/* IsAssignmentOp() relies on this block of enum values being */	\
@@ -146,6 +147,7 @@ namespace solidity::langutil
 	K(Assembly, "assembly", 0)                                         \
 	K(Break, "break", 0)                                               \
 	K(Catch, "catch", 0)                                               \
+	K(ChanCreate, "chancreate", 0)                                     \
 	K(Constant, "constant", 0)                                         \
 	K(Constructor, "constructor", 0)                                   \
 	K(Continue, "continue", 0)                                         \
@@ -194,6 +196,7 @@ namespace solidity::langutil
 	K(View, "view", 0)                                                 \
 	K(Virtual, "virtual", 0)                                           \
 	K(While, "while", 0)                                               \
+	K(Yield, "yield", 0)                                               \
 	\
 	/* Ether subdenominations */                                       \
 	K(SubWei, "wei", 0)                                                \

--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -598,6 +598,7 @@ bool ControlFlowBuilder::visit(VariableDeclaration const& _variableDeclaration)
 	return true;
 }
 
+//TODO: ChannelReceiveStatement
 bool ControlFlowBuilder::visit(VariableDeclarationStatement const& _variableDeclarationStatement)
 {
 	solAssert(!!m_currentNode, "");

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -62,6 +62,7 @@ int magicVariableToID(std::string const& _name)
 	else if (_name == "type") return -27;
 	else if (_name == "this") return -28;
 	else if (_name == "yield") return -29;
+	else if (_name == "chancreate") return -30;
 	else
 		solAssert(false, "Unknown magic variable: \"" + _name + "\".");
 }
@@ -104,6 +105,7 @@ inline vector<shared_ptr<MagicVariableDeclaration const>> constructMagicVariable
 			FunctionType::Options::withArbitraryParameters()
 		)),
 		magicVarDecl("yield", TypeProvider::function(strings{}, strings{}, FunctionType::Kind::Yield, StateMutability::Pure)),
+		magicVarDecl("chancreate", TypeProvider::function(strings{"uint8"}, strings{"channel"}, FunctionType::Kind::ChanCreate)),
 	};
 }
 

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -108,6 +108,15 @@ void ReferencesResolver::endVisit(VariableDeclarationStatement const& _varDeclSt
 			m_resolver.activateVariable(var->name());
 }
 
+void ReferencesResolver::endVisit(ChannelReceiveStatement const& _channelReceiveStatement)
+{
+	if (!m_resolveInsideCode)
+		return;
+	for (auto const& var: _channelReceiveStatement.declarations())
+		if (var)
+			m_resolver.activateVariable(var->name());
+}
+
 bool ReferencesResolver::visit(VariableDeclaration const& _varDecl)
 {
 	if (_varDecl.documentation())

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -75,6 +75,7 @@ private:
 	bool visit(ForStatement const& _for) override;
 	void endVisit(ForStatement const& _for) override;
 	void endVisit(VariableDeclarationStatement const& _varDeclStatement) override;
+	void endVisit(ChannelReceiveStatement const& _channelReceiveStatement) override;
 	bool visit(VariableDeclaration const& _varDecl) override;
 	bool visit(Identifier const& _identifier) override;
 	bool visit(FunctionDefinition const& _functionDefinition) override;

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1334,6 +1334,35 @@ void TypeChecker::endVisit(ArrayTypeName const& _typeName)
 	);
 }
 
+bool TypeChecker::visit(ChannelReceiveStatement const& _statement)
+{
+	if (!_statement.channel())
+	{
+		m_errorReporter.typeError(1234_error, _statement.location(), "Channel receive statement without channel.");
+		return false;
+	}
+
+	// Check that the channel is a channel.
+	// TODO
+	//if (type(*_statement.channel())->category() != Type::Category::Channel)
+	//{
+	//	m_errorReporter.typeError(1234_error, _statement.location(), "Channel receive statement with non-channel channel.");
+	//	return false;
+	//}
+
+	// Check that the channel is a channel of the correct type.
+	// TODO
+	//ChannelType const& channelType = dynamic_cast<ChannelType const&>(*type(*_statement.channel()));
+	//if (channelType.elementType() != type(*_statement.expression()))
+	//{
+	//	m_errorReporter.typeError(1234_error, _statement.location(), "Channel receive statement with channel of wrong type.");
+	//	return false;
+	//}
+	_statement.channel()->accept(*this);
+
+	return false;
+}
+
 bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 {
 	if (!_statement.initialValue())

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1501,6 +1501,21 @@ void TypeChecker::endVisit(ExpressionStatement const& _statement)
 	}
 }
 
+// TODO TODO: Move above expressionstatement ( not an expression but a statement )/ inherit from expression statement
+bool TypeChecker::visit(ChannelSendStatement const& _statement)
+{
+	//expectType(_expression.channel(), *TypeProvider::channel());
+	_statement.value()->accept(*this);
+	_statement.channel()->accept(*this);
+
+	//_statement.annotation().isConstant = false; // TODO: type(_expression.value())->isConstant();
+	//_statement.annotation().type = type(_expression.value());
+	//_statement.annotation().isPure = false; // type(_expression.value())->isPure();
+	//_statement.annotation().isLValue = false; // type(_expression.value())->isLValue();
+
+	return false;
+}
+
 bool TypeChecker::visit(Conditional const& _conditional)
 {
 	expectType(_conditional.condition(), *TypeProvider::boolean());

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -152,6 +152,7 @@ private:
 	bool visit(VariableDeclarationStatement const& _variable) override;
 	bool visit(ChannelReceiveStatement const& _variable) override;
 	void endVisit(ExpressionStatement const& _statement) override;
+	bool visit(ChannelSendStatement const& _expression) override;
 	bool visit(Conditional const& _conditional) override;
 	bool visit(Assignment const& _assignment) override;
 	bool visit(TupleExpression const& _tuple) override;

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -150,6 +150,7 @@ private:
 	void endVisit(SpawnStatement const& _spawn) override;
 	void endVisit(RevertStatement const& _revert) override;
 	bool visit(VariableDeclarationStatement const& _variable) override;
+	bool visit(ChannelReceiveStatement const& _variable) override;
 	void endVisit(ExpressionStatement const& _statement) override;
 	bool visit(Conditional const& _conditional) override;
 	bool visit(Assignment const& _assignment) override;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1925,7 +1925,7 @@ public:
 	std::vector<ASTPointer<VariableDeclaration>> const& declarations() const { return m_variables; }
 	Expression const* initialValue() const { return m_initialValue.get(); }
 
-private:
+protected:
 	/// List of variables, some of which can be empty pointers (unnamed components).
 	/// Note that the ``m_value`` member of these is unused. Instead, ``m_initialValue``
 	/// below is used, because the initial value can be a single expression assigned
@@ -1933,6 +1933,22 @@ private:
 	std::vector<ASTPointer<VariableDeclaration>> m_variables;
 	/// The assigned expression / initial value.
 	ASTPointer<Expression> m_initialValue;
+};
+
+class ChannelReceiveStatement: public VariableDeclarationStatement
+{
+public:
+	ChannelReceiveStatement(
+		int64_t _id,
+		SourceLocation const& _location,
+		ASTPointer<ASTString> const& _docString,
+		std::vector<ASTPointer<VariableDeclaration>> _variables,
+		ASTPointer<Expression> _channel
+	):
+		VariableDeclarationStatement(_id, _location, _docString, std::move(_variables), std::move(_channel)) {}
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
+	Expression const* channel() const { return m_initialValue.get(); }
 };
 
 /**

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1969,8 +1969,30 @@ public:
 
 	Expression const& expression() const { return *m_expression; }
 
-private:
+protected:
 	ASTPointer<Expression> m_expression;
+};
+
+class ChannelSendStatement: public ExpressionStatement
+{
+public:
+	ChannelSendStatement(
+		int64_t _id,
+		SourceLocation const& _location,
+		ASTPointer<ASTString> const& _docString,
+		ASTPointer<Expression> _expression, //TODO: just use _value?
+		ASTPointer<Expression> _channel
+	):
+		ExpressionStatement(_id, _location, _docString, std::move(_expression)),
+		m_channel(std::move(_channel)) {}
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
+
+	Expression const* channel() const { return m_channel.get(); }
+	Expression const* value() const { return m_expression.get(); }
+
+private:
+	ASTPointer<Expression> m_channel;
 };
 
 /// @}

--- a/libsolidity/ast/ASTJsonExporter.cpp
+++ b/libsolidity/ast/ASTJsonExporter.cpp
@@ -774,6 +774,7 @@ bool ASTJsonExporter::visit(RevertStatement const& _node)
 	return false;
 }
 
+//TODO: ChannelReceiveStatement
 bool ASTJsonExporter::visit(VariableDeclarationStatement const& _node)
 {
 	Json::Value varDecs(Json::arrayValue);

--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -96,6 +96,7 @@ public:
 	virtual bool visit(VariableDeclarationStatement& _node) { return visitNode(_node); }
 	virtual bool visit(ChannelReceiveStatement& _node) { return visitNode(_node); }
 	virtual bool visit(ExpressionStatement& _node) { return visitNode(_node); }
+	virtual bool visit(ChannelSendStatement& _node) { return visitNode(_node); }
 	virtual bool visit(Conditional& _node) { return visitNode(_node); }
 	virtual bool visit(Assignment& _node) { return visitNode(_node); }
 	virtual bool visit(TupleExpression& _node) { return visitNode(_node); }
@@ -155,6 +156,7 @@ public:
 	virtual void endVisit(VariableDeclarationStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(ChannelReceiveStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(ExpressionStatement& _node) { endVisitNode(_node); }
+	virtual void endVisit(ChannelSendStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(Conditional& _node) { endVisitNode(_node); }
 	virtual void endVisit(Assignment& _node) { endVisitNode(_node); }
 	virtual void endVisit(TupleExpression& _node) { endVisitNode(_node); }
@@ -236,6 +238,7 @@ public:
 	virtual bool visit(VariableDeclarationStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(ChannelReceiveStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(ExpressionStatement const& _node) { return visitNode(_node); }
+	virtual bool visit(ChannelSendStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(Conditional const& _node) { return visitNode(_node); }
 	virtual bool visit(Assignment const& _node) { return visitNode(_node); }
 	virtual bool visit(TupleExpression const& _node) { return visitNode(_node); }
@@ -295,6 +298,7 @@ public:
 	virtual void endVisit(VariableDeclarationStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(ChannelReceiveStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(ExpressionStatement const& _node) { endVisitNode(_node); }
+	virtual void endVisit(ChannelSendStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(Conditional const& _node) { endVisitNode(_node); }
 	virtual void endVisit(Assignment const& _node) { endVisitNode(_node); }
 	virtual void endVisit(TupleExpression const& _node) { endVisitNode(_node); }

--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -94,6 +94,7 @@ public:
 	virtual bool visit(SpawnStatement& _node) { return visitNode(_node); }
 	virtual bool visit(RevertStatement& _node) { return visitNode(_node); }
 	virtual bool visit(VariableDeclarationStatement& _node) { return visitNode(_node); }
+	virtual bool visit(ChannelReceiveStatement& _node) { return visitNode(_node); }
 	virtual bool visit(ExpressionStatement& _node) { return visitNode(_node); }
 	virtual bool visit(Conditional& _node) { return visitNode(_node); }
 	virtual bool visit(Assignment& _node) { return visitNode(_node); }
@@ -152,6 +153,7 @@ public:
 	virtual void endVisit(SpawnStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(RevertStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(VariableDeclarationStatement& _node) { endVisitNode(_node); }
+	virtual void endVisit(ChannelReceiveStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(ExpressionStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(Conditional& _node) { endVisitNode(_node); }
 	virtual void endVisit(Assignment& _node) { endVisitNode(_node); }
@@ -232,6 +234,7 @@ public:
 	virtual bool visit(SpawnStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(RevertStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(VariableDeclarationStatement const& _node) { return visitNode(_node); }
+	virtual bool visit(ChannelReceiveStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(ExpressionStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(Conditional const& _node) { return visitNode(_node); }
 	virtual bool visit(Assignment const& _node) { return visitNode(_node); }
@@ -290,6 +293,7 @@ public:
 	virtual void endVisit(SpawnStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(RevertStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(VariableDeclarationStatement const& _node) { endVisitNode(_node); }
+	virtual void endVisit(ChannelReceiveStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(ExpressionStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(Conditional const& _node) { endVisitNode(_node); }
 	virtual void endVisit(Assignment const& _node) { endVisitNode(_node); }

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -820,6 +820,26 @@ void ChannelReceiveStatement::accept(ASTConstVisitor& _visitor) const
 	_visitor.endVisit(*this);
 }
 
+void ChannelSendStatement::accept(ASTVisitor& _visitor)
+{
+	if (_visitor.visit(*this))
+	{
+		m_expression->accept(_visitor);
+		m_channel->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
+void ChannelSendStatement::accept(ASTConstVisitor& _visitor) const
+{
+	if (_visitor.visit(*this))
+	{
+		m_expression->accept(_visitor);
+		m_channel->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
 void Conditional::accept(ASTVisitor& _visitor)
 {
 	if (_visitor.visit(*this))

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -794,6 +794,32 @@ void VariableDeclarationStatement::accept(ASTConstVisitor& _visitor) const
 	_visitor.endVisit(*this);
 }
 
+void ChannelReceiveStatement::accept(ASTVisitor& _visitor)
+{
+	if (_visitor.visit(*this))
+	{
+		for (ASTPointer<VariableDeclaration> const& var: m_variables)
+			if (var)
+				var->accept(_visitor);
+		if (m_initialValue)
+			m_initialValue->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
+void ChannelReceiveStatement::accept(ASTConstVisitor& _visitor) const
+{
+	if (_visitor.visit(*this))
+	{
+		for (ASTPointer<VariableDeclaration> const& var: m_variables)
+			if (var)
+				var->accept(_visitor);
+		if (m_initialValue)
+			m_initialValue->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
 void Conditional::accept(ASTVisitor& _visitor)
 {
 	if (_visitor.visit(*this))

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -41,6 +41,8 @@ TupleType const TypeProvider::m_emptyTuple{};
 AddressType const TypeProvider::m_payableAddress{StateMutability::Payable};
 AddressType const TypeProvider::m_address{StateMutability::NonPayable};
 
+ChannelType const TypeProvider::m_channel{};
+
 array<unique_ptr<IntegerType>, 32> const TypeProvider::m_intM{{
 	{make_unique<IntegerType>(8 * 1, IntegerType::Modifier::Signed)},
 	{make_unique<IntegerType>(8 * 2, IntegerType::Modifier::Signed)},
@@ -247,6 +249,8 @@ Type const* TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken const& 
 	}
 	case Token::Bool:
 		return boolean();
+	case Token::Channel:
+		return channel();
 	case Token::Bytes:
 		return bytesStorage();
 	case Token::String:

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -62,6 +62,7 @@ public:
 
 	/// @returns boolean type.
 	static BoolType const* boolean() noexcept { return &m_boolean; }
+	static ChannelType const* channel() noexcept { return &m_channel; }
 
 	static FixedBytesType const* byte() { return fixedBytes(1); }
 	static FixedBytesType const* fixedBytes(unsigned m) { return m_bytesM.at(m - 1).get(); }
@@ -212,6 +213,8 @@ private:
 
 	static BoolType const m_boolean;
 	static InaccessibleDynamicType const m_inaccessibleDynamic;
+
+	static ChannelType const m_channel;
 
 	/// These are lazy-initialized because they depend on `byte` being available.
 	static std::unique_ptr<ArrayType> m_bytesStorage;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3007,6 +3007,7 @@ string FunctionType::richIdentifier() const
 	case Kind::BareDelegateCall: id += "baredelegatecall"; break;
 	case Kind::BareStaticCall: id += "barestaticcall"; break;
 	case Kind::Yield: id += "yield"; break;
+	case Kind::ChanCreate: id += "chancreate"; break;
 	case Kind::Creation: id += "creation"; break;
 	case Kind::Send: id += "send"; break;
 	case Kind::Transfer: id += "transfer"; break;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1411,6 +1411,33 @@ TypeResult BoolType::binaryOperatorResult(Token _operator, Type const* _other) c
 		return nullptr;
 }
 
+u256 ChannelType::literalValue(Literal const* _literal) const
+{
+	solAssert(_literal, "");
+	return u256(_literal->valueWithoutUnderscores());
+}
+
+TypeResult ChannelType::unaryOperatorResult(Token _operator) const
+{
+	//TODO: things
+	if (_operator == Token::Delete)
+		return TypeProvider::emptyTuple();
+	else if (_operator == Token::Not)
+		return this;
+	else
+		return nullptr;
+}
+
+TypeResult ChannelType::binaryOperatorResult(Token _operator, Type const* _other) const
+{
+	if (category() != _other->category())
+		return nullptr;
+	if (_operator == Token::Equal || _operator == Token::NotEqual || _operator == Token::And || _operator == Token::Or)
+		return _other;
+	else
+		return nullptr;
+}
+
 Type const* ContractType::encodingType() const
 {
 	if (isSuper())

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1223,6 +1223,7 @@ public:
 		BareDelegateCall, ///< DELEGATECALL without function hash
 		BareStaticCall, ///< STATICCALL without function hash
 		Yield, ///< yield coroutine
+		ChanCreate, ///< create channel
 		Creation, ///< external call using CREATE
 		Send, ///< CALL, but without data and gas
 		Transfer, ///< CALL, but without data and throws on error

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -175,7 +175,7 @@ public:
 	enum class Category
 	{
 		Address, Integer, RationalNumber, StringLiteral, Bool, FixedPoint, Array, ArraySlice,
-		FixedBytes, Contract, Struct, Function, Enum, UserDefinedValueType, Tuple,
+		FixedBytes, Contract, Struct, Function, Enum, UserDefinedValueType, Tuple, Channel,
 		Mapping, TypeType, Modifier, Magic, Module,
 		InaccessibleDynamic
 	};
@@ -696,6 +696,29 @@ public:
 	bool nameable() const override { return true; }
 
 	std::string toString(bool) const override { return "bool"; }
+	u256 literalValue(Literal const* _literal) const override;
+	Type const* encodingType() const override { return this; }
+	TypeResult interfaceType(bool) const override { return this; }
+};
+
+/**
+ * The Channel type.
+ */
+class ChannelType: public Type
+{
+public:
+	Category category() const override { return Category::Channel; }
+	std::string richIdentifier() const override { return "t_channel"; }
+	TypeResult unaryOperatorResult(Token _operator) const override;
+	TypeResult binaryOperatorResult(Token _operator, Type const* _other) const override;
+
+	unsigned calldataEncodedSize(bool _padded) const override{ return _padded ? 32 : 1; }
+	unsigned storageBytes() const override { return 1; }
+	bool leftAligned() const override { return false; }
+	bool isValueType() const override { return true; }
+	bool nameable() const override { return true; }
+
+	std::string toString(bool) const override { return "channel"; }
 	u256 literalValue(Literal const* _literal) const override;
 	Type const* encodingType() const override { return this; }
 	TypeResult interfaceType(bool) const override { return this; }

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1292,6 +1292,7 @@ void CompilerUtils::convertType(
 		if (_cleanupNeeded)
 			m_context << Instruction::ISZERO << Instruction::ISZERO;
 		break;
+	//TODO: Channel
 	default:
 		// we used to allow conversions from function to address
 		solAssert(!(stackTypeCategory == Type::Category::Function && targetTypeCategory == Type::Category::Address));

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1292,7 +1292,9 @@ void CompilerUtils::convertType(
 		if (_cleanupNeeded)
 			m_context << Instruction::ISZERO << Instruction::ISZERO;
 		break;
-	//TODO: Channel
+	case Type::Category::Channel:
+	    //TODO: Channel
+		break;
 	default:
 		// we used to allow conversions from function to address
 		solAssert(!(stackTypeCategory == Type::Category::Function && targetTypeCategory == Type::Category::Address));

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -1419,6 +1419,17 @@ bool ContractCompiler::visit(ChannelReceiveStatement const& _channelReceiveState
 	return false;
 }
 
+bool ContractCompiler::visit(ChannelSendStatement const& _channelSendStatement)
+{
+	StackHeightChecker checker(m_context);
+	CompilerContext::LocationSetter locationSetter(m_context, _channelSendStatement);
+	compileExpression(*_channelSendStatement.value());
+	compileExpression(*_channelSendStatement.channel());
+	m_context << Instruction::CHANSEND;
+	checker.check();
+	return false;
+}
+
 bool ContractCompiler::visit(ExpressionStatement const& _expressionStatement)
 {
 	StackHeightChecker checker(m_context);

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -1378,6 +1378,47 @@ bool ContractCompiler::visit(VariableDeclarationStatement const& _variableDeclar
 	return false;
 }
 
+//TODO
+bool ContractCompiler::visit(ChannelReceiveStatement const& _channelReceiveStatement)
+{
+	CompilerContext::LocationSetter locationSetter(m_context, _channelReceiveStatement);
+
+	for (auto decl: _channelReceiveStatement.declarations())
+		if (decl)
+			appendStackVariableInitialisation(*decl, !_channelReceiveStatement.channel());
+
+	StackHeightChecker checker(m_context);
+	if (Expression const* channel = _channelReceiveStatement.channel())
+	{
+		CompilerUtils utils(m_context);
+		compileExpression(*channel);
+		TypePointers valueTypes;
+		if (auto tupleType = dynamic_cast<TupleType const*>(channel->annotation().type))
+			valueTypes = tupleType->components();
+		else
+			valueTypes = TypePointers{channel->annotation().type};
+
+		m_context << Instruction::CHANRECV;
+
+		auto const& declarations = _channelReceiveStatement.declarations();
+		solAssert(declarations.size() == valueTypes.size(), "");
+		for (size_t i = 0; i < declarations.size(); ++i)
+		{
+			size_t j = declarations.size() - i - 1;
+			solAssert(!!valueTypes[j], "");
+			if (VariableDeclaration const* varDecl = declarations[j].get())
+			{
+				utils.convertType(*valueTypes[j], *varDecl->annotation().type);
+				utils.moveToStackVariable(*varDecl);
+			}
+			else
+				utils.popStackElement(*valueTypes[j]);
+		}
+	}
+	checker.check();
+	return false;
+}
+
 bool ContractCompiler::visit(ExpressionStatement const& _expressionStatement)
 {
 	StackHeightChecker checker(m_context);

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -120,6 +120,7 @@ private:
 	bool visit(SpawnStatement const& _spawn) override;
 	bool visit(RevertStatement const& _revert) override;
 	bool visit(VariableDeclarationStatement const& _variableDeclarationStatement) override;
+	bool visit(ChannelReceiveStatement const& _channelReceiveStatement) override;
 	bool visit(ExpressionStatement const& _expressionStatement) override;
 	bool visit(PlaceholderStatement const&) override;
 	bool visit(Block const& _block) override;

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -121,6 +121,7 @@ private:
 	bool visit(RevertStatement const& _revert) override;
 	bool visit(VariableDeclarationStatement const& _variableDeclarationStatement) override;
 	bool visit(ChannelReceiveStatement const& _channelReceiveStatement) override;
+	bool visit(ChannelSendStatement const& _channelSendStatement) override;
 	bool visit(ExpressionStatement const& _expressionStatement) override;
 	bool visit(PlaceholderStatement const&) override;
 	bool visit(Block const& _block) override;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -552,6 +552,18 @@ bool ExpressionCompiler::visit(BinaryOperation const& _binaryOperation)
 	return false;
 }
 
+//TODO: Remove?
+//bool ExpressionCompiler::visit(ChannelReceiveStatement const& _channelReceiveStatement)
+//{
+//	CompilerContext::LocationSetter locationSetter(m_context, _channelReceiveStatement);
+//
+//	// Get channel expression and push it on the stack
+//	// Expression const* channelExpression = _channelReceiveStatement.channel();
+//	//acceptAndConvert(channelExpression, Type::ChannelType, false);
+//	m_context << Instruction::CHANRECV;
+//	return false;
+//}
+
 bool ExpressionCompiler::visit(SpawnCall const& _spawnCall)
 {
 //	auto functionCallKind = *_spawnCall.annotation().kind;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -919,6 +919,11 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			// TODO: asserts and checks and things
 			m_context << Instruction::YIELD;
 			break;
+		case FunctionType::Kind::ChanCreate:
+			solAssert(arguments.size() == 1, "");
+			arguments.front()->accept(*this);
+			m_context << Instruction::CHANCREATE;
+			break;
 		case FunctionType::Kind::Revert:
 		{
 			if (arguments.empty())

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -294,6 +294,9 @@ string YulUtilFunctions::leftAlignFunction(Type const& _type)
 		case Type::Category::Bool:
 			templ("body", "aligned := " + leftAlignFunction(IntegerType(8)) + "(value)");
 			break;
+		case Type::Category::Channel:
+			templ("body", "aligned := " + leftAlignFunction(IntegerType(8)) + "(value)");
+			break;
 		case Type::Category::FixedPoint:
 			solUnimplemented("Fixed point types not implemented.");
 			break;
@@ -3412,6 +3415,15 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 				.render();
 			break;
 		}
+		case Type::Category::Channel:
+		{
+			solAssert(_from == _to, "Invalid conversion for channel.");
+              body =
+                  Whiskers("converted := <clean>(value)")
+                  ("clean", cleanupFunction(_from))
+                  .render();
+			break;
+		}
 		case Type::Category::FixedPoint:
 			solUnimplemented("Fixed point types not implemented.");
 			break;
@@ -3816,6 +3828,9 @@ string YulUtilFunctions::cleanupFunction(Type const& _type)
 		case Type::Category::Bool:
 			templ("body", "cleaned := iszero(iszero(value))");
 			break;
+		case Type::Category::Channel:
+			templ("body", "cleaned := value");
+			break;
 		case Type::Category::FixedPoint:
 			solUnimplemented("Fixed point types not implemented.");
 			break;
@@ -3899,6 +3914,7 @@ string YulUtilFunctions::validatorFunction(Type const& _type, bool _revertOnFail
 		case Type::Category::Integer:
 		case Type::Category::RationalNumber:
 		case Type::Category::Bool:
+		case Type::Category::Channel:
 		case Type::Category::FixedPoint:
 		case Type::Category::Function:
 		case Type::Category::Array:

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1176,7 +1176,9 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 	case FunctionType::Kind::ChanCreate:
 	{
 		// TODO: sol asserts
-		appendCode() << "chancreate(" << IRVariable(*arguments[0]).commaSeparatedList() << ")\n";
+		string const yulChannelVar = IRVariable(_functionCall).name();
+		appendCode() << "let " << yulChannelVar << " := chancreate("
+			<< IRVariable(*arguments[0]).commaSeparatedList() << ")\n";
 		break;
 	}
 	case FunctionType::Kind::ABIEncode:

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -415,6 +415,16 @@ void IRGeneratorForStatements::endVisit(ChannelReceiveStatement const& _statemen
 	appendCode() << "chanrecv(" << IRVariable(*channel).commaSeparatedList() << ")\n";
 }
 
+void IRGeneratorForStatements::endVisit(ChannelSendStatement const& _statement)
+{
+	setLocation(_statement);
+
+	Expression const* channel = _statement.channel();
+	Expression const* value = _statement.value();
+
+	appendCode() << "chansend(" << IRVariable(*channel).commaSeparatedList() << ", " << IRVariable(*value).commaSeparatedList() << ")\n";
+}
+
 bool IRGeneratorForStatements::visit(Conditional const& _conditional)
 {
 	_conditional.condition().accept(*this);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1173,6 +1173,12 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		appendCode() << "yield()\n";
 		break;
 	}
+	case FunctionType::Kind::ChanCreate:
+	{
+		// TODO: sol asserts
+		appendCode() << "chancreate(" << IRVariable(*arguments[0]).commaSeparatedList() << ")\n";
+		break;
+	}
 	case FunctionType::Kind::ABIEncode:
 	case FunctionType::Kind::ABIEncodePacked:
 	case FunctionType::Kind::ABIEncodeWithSelector:

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -404,6 +404,17 @@ void IRGeneratorForStatements::endVisit(VariableDeclarationStatement const& _var
 			}
 }
 
+void IRGeneratorForStatements::endVisit(ChannelReceiveStatement const& _statement)
+{
+	setLocation(_statement);
+
+	Expression const* channel = _statement.channel();
+	VariableDeclaration const& varDecl = *_statement.declarations().front();
+	define(m_context.addLocalVariable(varDecl));
+
+	appendCode() << "chanrecv(" << IRVariable(*channel).commaSeparatedList() << ")\n";
+}
+
 bool IRGeneratorForStatements::visit(Conditional const& _conditional)
 {
 	_conditional.condition().accept(*this);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -106,6 +106,7 @@ public:
 	std::string constantValueFunction(VariableDeclaration const& _constant);
 
 	void endVisit(VariableDeclarationStatement const& _variableDeclaration) override;
+	void endVisit(ChannelReceiveStatement const& _channelReceive) override;
 	bool visit(Conditional const& _conditional) override;
 	bool visit(Assignment const& _assignment) override;
 	bool visit(TupleExpression const& _tuple) override;

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -107,6 +107,7 @@ public:
 
 	void endVisit(VariableDeclarationStatement const& _variableDeclaration) override;
 	void endVisit(ChannelReceiveStatement const& _channelReceive) override;
+	void endVisit(ChannelSendStatement const& _channelSend) override;
 	bool visit(Conditional const& _conditional) override;
 	bool visit(Assignment const& _assignment) override;
 	bool visit(TupleExpression const& _tuple) override;

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -639,6 +639,9 @@ void SMTEncoder::endVisit(FunctionCall const& _funCall)
 	case FunctionType::Kind::Yield:
 		visitYield(_funCall);
 		break;
+	case FunctionType::Kind::ChanCreate:
+		visitChanCreate(_funCall);
+		break;
 	case FunctionType::Kind::External:
 		if (isPublicGetter(_funCall.expression()))
 			visitPublicGetter(_funCall);
@@ -865,6 +868,17 @@ void SMTEncoder::visitYield(FunctionCall const& _funCall)
 	auto const& funType = dynamic_cast<FunctionType const&>(*_funCall.expression().annotation().type);
     auto kind = funType.kind();
 	solAssert(kind == FunctionType::Kind::Yield, "");
+}
+
+void SMTEncoder::visitChanCreate(FunctionCall const& _funCall)
+{
+	auto const& funType = dynamic_cast<FunctionType const&>(*_funCall.expression().annotation().type);
+	auto kind = funType.kind();
+	solAssert(kind == FunctionType::Kind::ChanCreate, "");
+	auto const& args = _funCall.arguments();
+	solAssert(args.at(0), "");
+//	auto arg0 = expr(*args.at(0));
+//	TODO?
 }
 
 void SMTEncoder::visitAddMulMod(FunctionCall const& _funCall)

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -214,6 +214,7 @@ protected:
 	void visitCryptoFunction(FunctionCall const& _funCall);
 	void visitGasLeft(FunctionCall const& _funCall);
 	void visitYield(FunctionCall const& _funCall);
+	void visitChanCreate(FunctionCall const& _funCall);
 	virtual void visitAddMulMod(FunctionCall const& _funCall);
 	void visitWrapUnwrap(FunctionCall const& _funCall);
 	void visitObjectCreation(FunctionCall const& _funCall);

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -366,6 +366,11 @@ bool isBool(frontend::Type const& _type)
 	return _type.category() == frontend::Type::Category::Bool;
 }
 
+//bool isChannel(frontend::Type const& _type)
+//{
+//	return _type.category() == frontend::Type::Category::Channel;
+//}
+
 bool isFunction(frontend::Type const& _type)
 {
 	return _type.category() == frontend::Type::Category::Function;
@@ -480,6 +485,7 @@ smtutil::Expression zeroValue(frontend::Type const* _type)
 			return 0;
 		if (isBool(*_type))
 			return smtutil::Expression(false);
+		//TODO: Channel
 		if (isArray(*_type) || isMapping(*_type))
 		{
 			auto tupleSort = dynamic_pointer_cast<TupleSort>(smtSort(*_type));

--- a/libsolidity/lsp/SemanticTokensBuilder.cpp
+++ b/libsolidity/lsp/SemanticTokensBuilder.cpp
@@ -42,6 +42,7 @@ optional<SemanticTokenType> semanticTokenTypeForType(frontend::Type const* _type
 	{
 	case frontend::Type::Category::Address: return SemanticTokenType::Class;
 	case frontend::Type::Category::Bool: return SemanticTokenType::Number;
+	case frontend::Type::Category::Channel: return SemanticTokenType::Number;
 	case frontend::Type::Category::Enum: return SemanticTokenType::Enum;
 	case frontend::Type::Category::Function: return SemanticTokenType::Function;
 	case frontend::Type::Category::Integer: return SemanticTokenType::Number;

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1797,6 +1797,13 @@ ASTPointer<VariableDeclarationStatement> Parser::parseVariableDeclarationStateme
 		value = parseExpression();
 		nodeFactory.setEndPositionFromNode(value);
 	}
+	else if (m_scanner->currentToken() == Token::LeftArrow)
+	{
+		advance();
+		ASTPointer<Expression> channel = parseExpression();
+		nodeFactory.setEndPositionFromNode(channel);
+		return nodeFactory.createNode<ChannelReceiveStatement>(_docString, variables, channel);
+	}
 	return nodeFactory.createNode<VariableDeclarationStatement>(_docString, variables, value);
 }
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1814,6 +1814,14 @@ ASTPointer<ExpressionStatement> Parser::parseExpressionStatement(
 {
 	RecursionGuard recursionGuard(*this);
 	ASTPointer<Expression> expression = parseExpression(_partialParserResult);
+	if (m_scanner->currentToken() == Token::RightArrow)
+	{
+		advance();
+		ASTPointer<Expression> channel = parseExpression();
+		ASTNodeFactory nodeFactory(*this, expression);
+		nodeFactory.setEndPositionFromNode(channel);
+		return nodeFactory.createNode<ChannelSendStatement>(_docString, expression, channel);
+	}
 	return ASTNodeFactory(*this, expression).createNode<ExpressionStatement>(_docString, expression);
 }
 
@@ -1842,6 +1850,14 @@ ASTPointer<Expression> Parser::parseExpression(
 		nodeFactory.setEndPositionFromNode(falseExpression);
 		return nodeFactory.createNode<Conditional>(expression, trueExpression, falseExpression);
 	}
+	//else if (m_scanner->currentToken() == Token::RightArrow)
+	//{
+	//	advance();
+	//	ASTPointer<Expression> channel = parseExpression();
+	//	ASTNodeFactory nodeFactory(*this, expression);
+	//	nodeFactory.setEndPositionFromNode(channel);
+	//	return nodeFactory.createNode<ChannelSendExpression>(expression, channel);
+	//}
 	else
 		return expression;
 }

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -374,6 +374,9 @@ u256 EVMInstructionInterpreter::eval(
 	case Instruction::POP:
 		break;
 	// --------------- invalid in strict assembly ---------------
+	case Instruction::CHANCREATE:
+	case Instruction::CHANSEND:
+	case Instruction::CHANRECV:
 	case Instruction::YIELD:
 	case Instruction::SPAWN:
 	case Instruction::JUMP:


### PR DESCRIPTION
Add solidity compilation for channels, which are added into the evm as part of this PR: https://github.com/FraktalLabs/go-ethereum/pull/2
Channel design inspired by this article : https://abhinavsarkar.net/posts/implementing-co-4/

Yul syntax : 
`let channelBufferSize := 0x03`
`let channel := chancreate(channelBufferSize)`
`let value := chanrecv(channel)`
`chansend(channel, 0x42)`

Solidity syntax : 
`uint8 channelBufferSize = 0x03;`
`channel Chan = chancreate(channelBufferSize);`
`uint256 value <- Chan;`
`value -> Chan;`