### PR TITLE
Clog setup for the Solidity compiler(s)

### DIFF
--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -20,6 +20,7 @@ Bytes: 'bytes';
 Calldata: 'calldata';
 Catch: 'catch';
 ChanCreate: 'chancreate';
+Clog: 'clog';
 Constant: 'constant';
 Constructor: 'constructor';
 Continue: 'continue';
@@ -296,7 +297,8 @@ YulEVMBuiltin:
 	| 'delegatecall' | 'staticcall' | 'return' | 'revert' | 'selfdestruct' | 'invalid'
 	| 'log0' | 'log1' | 'log2' | 'log3' | 'log4' | 'chainid' | 'origin' | 'gasprice'
 	| 'blockhash' | 'coinbase' | 'timestamp' | 'number' | 'difficulty' | 'prevrandao'
-	| 'gaslimit' | 'basefee' | 'yield' | 'spawn' | 'chancreate', 'chansend', 'chanrecv';
+	| 'gaslimit' | 'basefee' | 'yield' | 'spawn' | 'chancreate', 'chansend', 'chanrecv'
+  | 'clog';
 
 YulLBrace: '{' -> pushMode(YulMode);
 YulRBrace: '}' -> popMode;

--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -68,6 +68,7 @@ NumberUnit: 'wei' | 'gwei' | 'ether' | 'seconds' | 'minutes' | 'hours' | 'days' 
 Override: 'override';
 Payable: 'payable';
 Pragma: 'pragma' -> pushMode(PragmaMode);
+Print: 'print';
 Private: 'private';
 Public: 'public';
 Pure: 'pure';

--- a/libevmasm/Instruction.cpp
+++ b/libevmasm/Instruction.cpp
@@ -172,6 +172,7 @@ std::map<std::string, Instruction> const solidity::evmasm::c_instructions =
 	{ "CHANRECV", Instruction::CHANRECV },
 	{ "SPAWN", Instruction::SPAWN },
 	{ "YIELD", Instruction::YIELD },
+	{ "CLOG", Instruction::CLOG },
 	{ "RETURN", Instruction::RETURN },
 	{ "DELEGATECALL", Instruction::DELEGATECALL },
 	{ "CREATE2", Instruction::CREATE2 },
@@ -327,6 +328,7 @@ static std::map<Instruction, InstructionInfo> const c_instructionInfo =
     { Instruction::CHANRECV,    { "CHANRECV",       0, 1, 1, true, Tier::VeryLow } }, // TODO
 	{ Instruction::SPAWN,       { "SPAWN",          0, 1, 0, true, Tier::VeryLow } }, // TODO: Gase, Side effect
 	{ Instruction::YIELD,       { "YIELD",          0, 0, 0, true, Tier::VeryLow } }, // TODO: Gas & SideEffects
+	{ Instruction::CLOG,        { "CLOG",           0, 1, 0, false, Tier::VeryLow } }, // TODO
 	{ Instruction::CREATE2,		{ "CREATE2",		0, 4, 1, true, Tier::Special } },
 	{ Instruction::REVERT,		{ "REVERT",		0, 2, 0, true, Tier::Zero } },
 	{ Instruction::INVALID,		{ "INVALID",		0, 0, 0, true, Tier::Zero } },

--- a/libevmasm/Instruction.h
+++ b/libevmasm/Instruction.h
@@ -175,6 +175,7 @@ enum class Instruction: uint8_t
 	LOG2,				///< Makes a log entry; 2 topics.
 	LOG3,				///< Makes a log entry; 3 topics.
 	LOG4,				///< Makes a log entry; 4 topics.
+	CLOG,               ///< Logs encoded string to console
 
 	CREATE = 0xf0,		///< create a new account with associated code
 	CALL,				///< message-call into an account

--- a/libevmasm/SimplificationRule.h
+++ b/libevmasm/SimplificationRule.h
@@ -152,6 +152,7 @@ struct EVMBuiltins
 	static auto constexpr CHANRECV = PatternGenerator<Instruction::CHANRECV>{};
 	static auto constexpr SPAWN = PatternGenerator<Instruction::SPAWN>{};
 	static auto constexpr YIELD = PatternGenerator<Instruction::YIELD>{};
+	static auto constexpr CLOG = PatternGenerator<Instruction::CLOG>{};
 	static auto constexpr CREATE2 = PatternGenerator<Instruction::CREATE2>{};
 	static auto constexpr REVERT = PatternGenerator<Instruction::REVERT>{};
 	static auto constexpr INVALID = PatternGenerator<Instruction::INVALID>{};

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -63,6 +63,7 @@ int magicVariableToID(std::string const& _name)
 	else if (_name == "this") return -28;
 	else if (_name == "yield") return -29;
 	else if (_name == "chancreate") return -30;
+	else if (_name == "print") return -31;
 	else
 		solAssert(false, "Unknown magic variable: \"" + _name + "\".");
 }
@@ -106,6 +107,7 @@ inline vector<shared_ptr<MagicVariableDeclaration const>> constructMagicVariable
 		)),
 		magicVarDecl("yield", TypeProvider::function(strings{}, strings{}, FunctionType::Kind::Yield, StateMutability::Pure)),
 		magicVarDecl("chancreate", TypeProvider::function(strings{"uint8"}, strings{"channel"}, FunctionType::Kind::ChanCreate)),
+		magicVarDecl("print", TypeProvider::function(strings{"string memory"}, strings{}, FunctionType::Kind::Clog, StateMutability::Pure))
 	};
 }
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3035,6 +3035,7 @@ string FunctionType::richIdentifier() const
 	case Kind::BareStaticCall: id += "barestaticcall"; break;
 	case Kind::Yield: id += "yield"; break;
 	case Kind::ChanCreate: id += "chancreate"; break;
+	case Kind::Clog: id += "print"; break;
 	case Kind::Creation: id += "creation"; break;
 	case Kind::Send: id += "send"; break;
 	case Kind::Transfer: id += "transfer"; break;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1247,6 +1247,7 @@ public:
 		BareStaticCall, ///< STATICCALL without function hash
 		Yield, ///< yield coroutine
 		ChanCreate, ///< create channel
+		Clog, ///< console log
 		Creation, ///< external call using CREATE
 		Send, ///< CALL, but without data and gas
 		Transfer, ///< CALL, but without data and throws on error

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -931,6 +931,18 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			// TODO: asserts and checks and things
 			m_context << Instruction::YIELD;
 			break;
+		case FunctionType::Kind::Clog:
+		{
+			// stack layout: memory ptr
+			//_functionCall.expression().accept(*this);
+
+			// TODO?
+			//acceptAndConvert(*arguments.front(), *TypeProvider::uint256(), true);
+			arguments.front()->accept(*this);
+
+			m_context << Instruction::CLOG;
+			break;
+		}
 		case FunctionType::Kind::ChanCreate:
 			solAssert(arguments.size() == 1, "");
 			arguments.front()->accept(*this);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1194,6 +1194,11 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		appendCode() << "yield()\n";
 		break;
 	}
+	case FunctionType::Kind::Clog:
+	{
+		appendCode() << "clog(" << IRVariable(*arguments[0]).commaSeparatedList() << ")\n";
+		break;
+	}
 	case FunctionType::Kind::ChanCreate:
 	{
 		// TODO: sol asserts

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -639,6 +639,9 @@ void SMTEncoder::endVisit(FunctionCall const& _funCall)
 	case FunctionType::Kind::Yield:
 		visitYield(_funCall);
 		break;
+	case FunctionType::Kind::Clog:
+		visitClog(_funCall);
+		break;
 	case FunctionType::Kind::ChanCreate:
 		visitChanCreate(_funCall);
 		break;
@@ -868,6 +871,19 @@ void SMTEncoder::visitYield(FunctionCall const& _funCall)
 	auto const& funType = dynamic_cast<FunctionType const&>(*_funCall.expression().annotation().type);
     auto kind = funType.kind();
 	solAssert(kind == FunctionType::Kind::Yield, "");
+}
+
+void SMTEncoder::visitClog(FunctionCall const& _funCall)
+{
+	auto const& funType = dynamic_cast<FunctionType const&>(*_funCall.expression().annotation().type);
+	auto kind = funType.kind();
+	solAssert(kind == FunctionType::Kind::Clog, "");
+
+	// TODO
+	//auto const& args = _funCall.arguments();
+	//solAssert(args.at(0), "");
+	//auto arg0 = expr(*args.at(0));
+	//solAssert(arg0.sort->kind == smtutil::Kind::StringLiteral, "");
 }
 
 void SMTEncoder::visitChanCreate(FunctionCall const& _funCall)

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -214,6 +214,7 @@ protected:
 	void visitCryptoFunction(FunctionCall const& _funCall);
 	void visitGasLeft(FunctionCall const& _funCall);
 	void visitYield(FunctionCall const& _funCall);
+	void visitClog(FunctionCall const& _funCall);
 	void visitChanCreate(FunctionCall const& _funCall);
 	virtual void visitAddMulMod(FunctionCall const& _funCall);
 	void visitWrapUnwrap(FunctionCall const& _funCall);

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,7 +18,7 @@ mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 cmake .. -DUSE_Z3=OFF -DCMAKE_BUILD_TYPE="$BUILD_TYPE" "${@:2}"
-make -j2
+make -j8
 
 if [[ "${CI}" == "" ]]; then
 	echo "Installing ..."

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -379,6 +379,7 @@ u256 EVMInstructionInterpreter::eval(
 	case Instruction::CHANRECV:
 	case Instruction::YIELD:
 	case Instruction::SPAWN:
+	case Instruction::CLOG:
 	case Instruction::JUMP:
 	case Instruction::JUMPI:
 	case Instruction::JUMPDEST:


### PR DESCRIPTION
Compiler changes for evm clog PR : https://github.com/FraktalLabs/go-ethereum/pull/3

Yul setup with syntax like : 
```
mstore(0x00, 0x20)
mstore(0x20, 0x0d)
mstore(0x40, 0x48656c6c6f2c20576f726c642100000000000000000000000000000000000000)

clog(0x20)
```
Prints `Hello, World!`

Solidity setup with syntax like : 
```
string memory val = "Hello, World!"
print(val)
```